### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,15 +6,15 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-KEYWORD1    CY8C
+KEYWORD1	CY8C
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-KEYWORD2    init
-KEYWORD2    get_touch_botton_value
-KEYWORD2    get_touch_slider_value
+KEYWORD2	init
+KEYWORD2	get_touch_botton_value
+KEYWORD2	get_touch_slider_value
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords